### PR TITLE
Fix #38

### DIFF
--- a/make_progress.py
+++ b/make_progress.py
@@ -27,9 +27,11 @@ def get_progress() -> List[User]:
         for chap, max_cnt in zip(range(CHAPTER), QUESTIONS):
             # user/chapterXX の path (章だけ 1-indexed なので num+1)
             chapter_path = Path(user / f"chapter{chap+1:02d}")
-            # user/chapterXX に含まれる .py ファイルの数をカウント
+            # user/chapterXX に含まれる .py ファイルと .sh ファイルの数をカウント
+            py_file_cnt = len(list(chapter_path.glob("*.py")))
+            sh_file_cnt = len(list(chapter_path.glob("*.sh")))
             # 問題数は max_cnt が上限で、それ以上のファイル数が含まれる場合は max_cnt にする
-            solved_cnt = min(len(list(chapter_path.glob("*.py"))), max_cnt)
+            solved_cnt = min(py_file_cnt + sh_file_cnt, max_cnt)
             u.progress[chap] = solved_cnt
         progress.append(u)
 


### PR DESCRIPTION
*.sh に対応するようにしました。
ご検討の程、よろしくお願いいたします。

```py
[f for f in chapter_path.glob("*") if re.search("(py|sh)$", str(f))]
```

のように書いても良さそうです。